### PR TITLE
Apply edge-to-edge layout and transparent system bars with gradient background                                                                                           

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
             android:name=".features.main.MainActivity"
             android:exported="true"
             android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustResize"
             tools:ignore="LockedOrientationActivity"
             android:theme="@style/Theme.SeaCard">
             <intent-filter>
@@ -35,18 +36,21 @@
             android:name=".features.settings.SettingsActivity"
             android:exported="false"
             android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustResize"
             tools:ignore="LockedOrientationActivity"
             android:theme="@style/Theme.SeaCard" />
         <activity
             android:name=".features.scan.ScanCardActivity"
             android:exported="false"
             android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustResize"
             tools:ignore="LockedOrientationActivity"
             android:theme="@style/Theme.SeaCard" />
         <activity
             android:name=".features.detail.CardDetailActivity"
             android:exported="false"
             android:screenOrientation="portrait"
+            android:windowSoftInputMode="adjustResize"
             tools:ignore="LockedOrientationActivity"
             android:theme="@style/Theme.SeaCard" />
         <receiver

--- a/app/src/main/java/ru/merrcurys/seacard/core/design/SeaCardSystemBars.kt
+++ b/app/src/main/java/ru/merrcurys/seacard/core/design/SeaCardSystemBars.kt
@@ -2,6 +2,7 @@ package ru.merrcurys.seacard.core.design
 
 import android.graphics.Color
 import android.view.WindowManager
+import android.os.Build
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
@@ -17,6 +18,9 @@ fun ComponentActivity.applySeaCardSystemBarColors() {
         WindowManager.LayoutParams.FLAG_TRANSLUCENT_STATUS or
             WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION
     )
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        window.isNavigationBarContrastEnforced = false
+    }
     enableEdgeToEdge(
         statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),
         navigationBarStyle = SystemBarStyle.dark(Color.TRANSPARENT),

--- a/app/src/main/java/ru/merrcurys/seacard/features/detail/CardDetailActivity.kt
+++ b/app/src/main/java/ru/merrcurys/seacard/features/detail/CardDetailActivity.kt
@@ -73,6 +73,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
@@ -453,11 +454,10 @@ fun CardDetailScreen(
         }
     }
 
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-    ) {
-        Column {
+    Scaffold(
+        containerColor = Color.Transparent,
+        contentWindowInsets = WindowInsets.safeDrawing,
+        topBar = {
             if (!showEditDialog) {
                 TopAppBar(
                     title = {
@@ -511,6 +511,13 @@ fun CardDetailScreen(
                     colors = TopAppBarDefaults.topAppBarColors(containerColor = topBarContainerColor)
                 )
             }
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .consumeWindowInsets(innerPadding)
+        ) {
             // Диалог удаления
             if (showDeleteDialog) {
                 AlertDialog(
@@ -551,10 +558,13 @@ fun CardDetailScreen(
                         if (normalizedName.isBlank()) {
                             editError = "Заполните имя карты"
                         } else {
-                            val type = editType.ifBlank { if (editCode.isBlank()) "none" else "code128" }
+                            val type =
+                                editType.ifBlank { if (editCode.isBlank()) "none" else "code128" }
                             val code = editCode
-                            val frontDirty = editFrontCoverRemoved || editFrontCoverUri != initialEditFrontUri
-                            val backDirty = editBackCoverRemoved || editBackCoverUri != initialEditBackUri
+                            val frontDirty =
+                                editFrontCoverRemoved || editFrontCoverUri != initialEditFrontUri
+                            val backDirty =
+                                editBackCoverRemoved || editBackCoverUri != initialEditBackUri
                             showEditDialog = false
                             editError = ""
                             onEdit(
@@ -578,7 +588,8 @@ fun CardDetailScreen(
                         resetEditDraft()
                         showEditDialog = false
                     },
-                    frontCoverUri = if (editFrontCoverRemoved) null else (editFrontCoverUri ?: frontCoverUri),
+                    frontCoverUri = if (editFrontCoverRemoved) null else (editFrontCoverUri
+                        ?: frontCoverUri),
                     backCoverUri = if (editBackCoverRemoved) null else editBackCoverUri,
                     onFrontCoverPick = {
                         if (hasCameraPermission) {
@@ -619,495 +630,550 @@ fun CardDetailScreen(
                         )
                     },
                 )
-            }
-            if (!showEditDialog) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(16.dp)
-                    .verticalScroll(rememberScrollState()),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(24.dp)
-            ) {
-                // Штрих-код или текстовый код (для карт без штрих-кода)
-                if (barcodeBitmap != null && cardCode.isNotBlank() && displayCodeType != "none") {
-                    val isSquareCode = displayCodeType == "qr" || displayCodeType == "datamatrix"
-                    val cardHeight = if (isSquareCode) 350.dp else 300.dp
-                    val imageHeight = if (displayCodeType == "qr" || displayCodeType == "datamatrix") 230.dp else 230.dp
-                    Card(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 16.dp, bottom = 8.dp)
-                            .height(cardHeight)
-                            .shadow(18.dp, RoundedCornerShape(28.dp)),
-                        colors = CardDefaults.cardColors(containerColor = Color.White),
-                        elevation = CardDefaults.cardElevation(defaultElevation = 18.dp),
-                        shape = RoundedCornerShape(28.dp),
-                        border = BorderStroke(1.dp, Color.LightGray.copy(alpha = 0.25f))
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(20.dp),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Image(
-                                bitmap = barcodeBitmap!!.asImageBitmap(),
-                                contentDescription = cardName,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(imageHeight)
-                            )
-                        }
-                    }
-                } else if (displayCodeType == "none" && cardCode.isNotBlank()) {
-                    Card(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 16.dp, bottom = 8.dp)
-                            .height(300.dp)
-                            .shadow(18.dp, RoundedCornerShape(28.dp)),
-                        colors = CardDefaults.cardColors(containerColor = Color.White),
-                        elevation = CardDefaults.cardElevation(defaultElevation = 18.dp),
-                        shape = RoundedCornerShape(28.dp),
-                        border = BorderStroke(1.dp, Color.LightGray.copy(alpha = 0.25f))
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(20.dp)
-                                .pointerInput(Unit) {
-                                    detectTapGestures(onLongPress = { copyToClipboard() })
-                                },
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .horizontalScroll(rememberScrollState()),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Text(
-                                    text = cardCode,
-                                    fontSize = plainCodeDisplayFontSize(cardCode),
-                                    fontWeight = FontWeight.Bold,
-                                    color = Color.Black,
-                                    textAlign = TextAlign.Center,
-                                    lineHeight = plainCodeDisplayFontSize(cardCode) * 1.15f,
-                                    modifier = Modifier.padding(vertical = 4.dp)
-                                )
-                            }
-                        }
-                    }
-                }
-                HorizontalDivider(
-                    modifier = Modifier.padding(horizontal = 32.dp),
-                    thickness = 1.dp,
-                    color = colorScheme.onSurface.copy(alpha = 0.2f)
-                )
-                // Код карты внизу
+            } else {
                 Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp)
+                        .verticalScroll(rememberScrollState()),
                     horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                    verticalArrangement = Arrangement.spacedBy(24.dp)
                 ) {
-                    // Текст кода карты — скрыт для карт без штрих-кода
-                    if (cardCode.isNotBlank() && displayCodeType != "none") {
-                    Card(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 10.dp),
-                        shape = RoundedCornerShape(22.dp),
-                        colors = CardDefaults.cardColors(containerColor = colorScheme.surface.copy(alpha = 0.20f)),
-                        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
-                    ) {
-                        Column(
+                    Spacer(modifier = Modifier.height(innerPadding.calculateTopPadding() + 8.dp))
+                    // Штрих-код или текстовый код (для карт без штрих-кода)
+                    if (barcodeBitmap != null && cardCode.isNotBlank() && displayCodeType != "none") {
+                        val isSquareCode =
+                            displayCodeType == "qr" || displayCodeType == "datamatrix"
+                        val cardHeight = if (isSquareCode) 350.dp else 300.dp
+                        val imageHeight =
+                            if (displayCodeType == "qr" || displayCodeType == "datamatrix") 230.dp else 230.dp
+                        Card(
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(vertical = 12.dp, horizontal = 12.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally
+                                .padding(top = 16.dp, bottom = 8.dp)
+                                .height(cardHeight)
+                                .shadow(18.dp, RoundedCornerShape(28.dp)),
+                            colors = CardDefaults.cardColors(containerColor = Color.White),
+                            elevation = CardDefaults.cardElevation(defaultElevation = 18.dp),
+                            shape = RoundedCornerShape(28.dp),
+                            border = BorderStroke(1.dp, Color.LightGray.copy(alpha = 0.25f))
                         ) {
-                            val formattedCode = formatBarcodeForStandard(cardCode, displayCodeType)
                             Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .horizontalScroll(rememberScrollState())
-                                    .pointerInput(Unit) {
-                                        detectTapGestures(
-                                            onLongPress = {
-                                                copyToClipboard()
-                                            }
-                                        )
-                                    },
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Text(
-                                    text = formattedCode,
-                                    fontSize = if (cardCode.length > 20) 20.sp else 28.sp,
-                                    fontWeight = FontWeight.Bold,
-                                    color = Color.White,
-                                    textAlign = TextAlign.Center,
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(vertical = 4.dp)
-                                )
-                            }
-                            Spacer(modifier = Modifier.height(6.dp))
-                            Row(
-                                modifier = Modifier.fillMaxWidth(),
-                                horizontalArrangement = Arrangement.Center,
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.TouchApp,
-                                    contentDescription = null,
-                                    tint = Color.White.copy(alpha = 0.7f),
-                                    modifier = Modifier.size(16.dp)
-                                )
-                                Spacer(modifier = Modifier.width(4.dp))
-                                Text(
-                                    text = "Долгое нажатие — скопировать",
-                                    fontSize = 11.sp,
-                                    color = Color.White.copy(alpha = 0.7f)
-                                )
-                            }
-                        }
-                    }
-                    }
-                    // Заметки и Обложка
-                    Spacer(modifier = Modifier.height(1.dp))
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 10.dp),
-                        horizontalArrangement = Arrangement.spacedBy(
-                            space = 12.dp,
-                            alignment = Alignment.CenterHorizontally
-                        ),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        // Кнопка "Заметки"
-                        Card(
-                            modifier = Modifier
-                                .weight(1f)
-                                .height(54.dp)
-                                .pointerInput(Unit) {
-                                    detectTapGestures(
-                                        onTap = { showNoteDialog = true }
-                                    )
-                                },
-                            shape = RoundedCornerShape(14.dp),
-                            colors = CardDefaults.cardColors(containerColor = colorScheme.surface.copy(alpha = 0.20f)),
-                            elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
-                        ) {
-                            Row(
                                 modifier = Modifier
                                     .fillMaxSize()
-                                    .padding(horizontal = 16.dp),
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally)
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.Edit,
-                                    contentDescription = "Заметки",
-                                    tint = Color.White,
-                                    modifier = Modifier.size(22.dp)
-                                )
-                                Text(
-                                    text = "Заметки",
-                                    color = Color.White,
-                                    fontSize = 15.sp,
-                                    fontWeight = FontWeight.Medium
-                                )
-                            }
-                        }
-                        // Кнопка "Обложка"
-                        Card(
-                            modifier = Modifier
-                                .weight(1f)
-                                .height(54.dp),
-                            shape = RoundedCornerShape(14.dp),
-                            colors = CardDefaults.cardColors(containerColor = colorScheme.surface.copy(alpha = 0.20f)),
-                            elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
-                        ) {
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .clickable(
-                                        interactionSource = remember { MutableInteractionSource() },
-                                        indication = null
-                                    ) { showCoverDialog = true }
-                                    .padding(horizontal = 16.dp),
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally)
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Default.Image,
-                                    contentDescription = "Обложка",
-                                    tint = Color.White,
-                                    modifier = Modifier.size(22.dp)
-                                )
-                                Text(
-                                    text = "Обложка",
-                                    color = Color.White,
-                                    fontSize = 15.sp,
-                                    fontWeight = FontWeight.Medium
-                                )
-                            }
-                        }
-                    }
-                }
-            }
-            }
-            // Диалог для заметки
-            if (showNoteDialog) {
-                AlertDialog(
-                    onDismissRequest = { showNoteDialog = false },
-                    title = { Text("Заметка к карте") },
-                    text = {
-                        Column {
-                            OutlinedTextField(
-                                value = noteDraft,
-                                onValueChange = {
-                                    if (it.length <= 100) {
-                                        noteDraft = it
-                                        noteError = ""
-                                    }
-                                },
-                                label = { Text("Введите заметку") },
-                                singleLine = false,
-                                maxLines = 4,
-                                modifier = Modifier.fillMaxWidth(),
-                                trailingIcon = {
-                                    if (noteDraft.isNotEmpty()) {
-                                        IconButton(onClick = { noteDraft = "" }) {
-                                            Icon(Icons.Default.Close, contentDescription = "Очистить")
-                                        }
-                                    }
-                                }
-                            )
-                            if (noteError.isNotEmpty()) {
-                                Text(noteError, color = Color.Red, fontSize = 13.sp)
-                            }
-                        }
-                    },
-                    confirmButton = {
-                        TextButton(
-                            onClick = {
-                                if (noteDraft.length <= 100) {
-                                    onSaveNote(noteDraft)
-                                    showNoteDialog = false
-                                } else {
-                                    noteError = "Максимум 100 символов"
-                                }
-                            }
-                        ) {
-                            Text("Сохранить")
-                        }
-                    },
-                    dismissButton = {
-                        TextButton(onClick = { showNoteDialog = false }) {
-                            Text("Отмена")
-                        }
-                    },
-                    containerColor = colorScheme.surface,
-                    titleContentColor = colorScheme.onSurface,
-                    textContentColor = colorScheme.onSurface
-                )
-            }
-            // Диалог выбора/просмотра обложки
-            if (showCoverDialog) {
-                AlertDialog(
-                    onDismissRequest = { showCoverDialog = false },
-                    title = { Text("Обложка карты") },
-                    text = {
-                        Column(
-                            horizontalAlignment = Alignment.CenterHorizontally,
-                            verticalArrangement = Arrangement.spacedBy(14.dp)
-                        ) {
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .aspectRatio(1.574f)
-                                    .clip(RoundedCornerShape(18.dp))
-                                    .background(colorScheme.surfaceVariant.copy(alpha = 0.7f))
-                                    .clickable {
-                                        when {
-                                            frontCoverPath != null && !frontCoverPath!!.startsWith("cards/") ->
-                                                showFullScreenImage = true to Uri.fromFile(File(frontCoverPath!!))
-                                            frontImageUri != null -> showFullScreenImage = true to frontImageUri
-                                            coverBitmap != null -> showFullScreenImage = true to null
-                                        }
-                                    },
+                                    .padding(20.dp),
                                 contentAlignment = Alignment.Center
-                            ) {
-                                val frontBitmap = frontCoverPath?.let { path ->
-                                    if (path.startsWith("cards/")) null
-                                    else try { BitmapFactory.decodeFile(path) } catch (_: Exception) { null }
-                                } ?: frontImageUri?.let { rememberBitmapFromUri(it) } ?: coverBitmap?.let { null }
-                                if (frontBitmap != null) {
-                                    Image(
-                                        bitmap = frontBitmap.asImageBitmap(),
-                                        contentDescription = "Лицевая обложка",
-                                        contentScale = ContentScale.Crop,
-                                        modifier = Modifier.fillMaxSize()
-                                    )
-                                } else if (coverBitmap != null) {
-                                    Image(
-                                        bitmap = coverBitmap,
-                                        contentDescription = "Лицевая обложка",
-                                        contentScale = ContentScale.Crop,
-                                        modifier = Modifier.fillMaxSize()
-                                    )
-                                } else {
-                                    Icon(
-                                        imageVector = Icons.Default.Image,
-                                        contentDescription = null,
-                                        tint = colorScheme.primary,
-                                        modifier = Modifier.size(48.dp)
-                                    )
-                                }
-                            }
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .aspectRatio(1.574f)
-                                    .clip(RoundedCornerShape(18.dp))
-                                    .background(colorScheme.surfaceVariant.copy(alpha = 0.7f))
-                                    .clickable {
-                                        backCoverPath?.let { path ->
-                                            showFullScreenImage = true to Uri.fromFile(File(path))
-                                        } ?: run {
-                                            if (backImageUri != null) {
-                                                showFullScreenImage = true to backImageUri
-                                            }
-                                        }
-                                    },
-                                contentAlignment = Alignment.Center
-                            ) {
-                                val backBitmap = if (backCoverPath != null) {
-                                    try {
-                                        BitmapFactory.decodeFile(backCoverPath)
-                                    } catch (_: Exception) { null }
-                                } else rememberBitmapFromUri(backImageUri)
-                                if (backBitmap != null) {
-                                    Image(
-                                        bitmap = backBitmap.asImageBitmap(),
-                                        contentDescription = "Тыльная обложка",
-                                        contentScale = ContentScale.Crop,
-                                        modifier = Modifier.fillMaxSize()
-                                    )
-                                } else {
-                                    Icon(
-                                        imageVector = Icons.Default.Image,
-                                        contentDescription = null,
-                                        tint = colorScheme.primary,
-                                        modifier = Modifier.size(48.dp)
-                                    )
-                                }
-                            }
-                            Text(
-                                text = "Нажмите на обложку, чтобы увеличить изображение. А изменить обложку, можно в меню изменения карты.",
-                                fontSize = 13.sp,
-                                color = colorScheme.onSurfaceVariant,
-                                textAlign = TextAlign.Center,
-                                modifier = Modifier.fillMaxWidth()
-                            )
-                        }
-                    },
-                    confirmButton = {
-                        TextButton(onClick = { showCoverDialog = false }) {
-                            Text("Готово")
-                        }
-                    },
-                    containerColor = colorScheme.surface,
-                    titleContentColor = colorScheme.onSurface,
-                    textContentColor = colorScheme.onSurface
-                )
-            }
-            // Полноэкранный просмотр изображения
-            if (showFullScreenImage.first) {
-                Dialog(onDismissRequest = { showFullScreenImage = false to null }) {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center
-                    ) {
-                        val uri = showFullScreenImage.second
-                        val bitmap = if (uri != null) rememberBitmapFromUri(uri)?.asImageBitmap() else coverBitmap
-                        if (bitmap != null) {
-                            var scale by remember { mutableStateOf(1f) }
-                            var offset by remember { mutableStateOf(Offset.Zero) }
-                            var lastOffset by remember { mutableStateOf(Offset.Zero) }
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth(0.98f)
-                                    .fillMaxHeight(0.98f)
-                                    .pointerInput(Unit) {
-                                        detectTransformGestures { _, pan, zoom, _ ->
-                                            scale = (scale * zoom).coerceIn(1f, 5f)
-                                            offset += pan
-                                        }
-                                    }
-                                    .pointerInput(Unit) {
-                                        detectTapGestures(onDoubleTap = {
-                                            scale = 1f
-                                            offset = Offset.Zero
-                                        })
-                                    }
                             ) {
                                 Image(
-                                    bitmap = bitmap,
-                                    contentDescription = null,
-                                    contentScale = ContentScale.Fit,
+                                    bitmap = barcodeBitmap!!.asImageBitmap(),
+                                    contentDescription = cardName,
                                     modifier = Modifier
-                                        .graphicsLayer(
-                                            scaleX = scale,
-                                            scaleY = scale,
-                                            translationX = offset.x,
-                                            translationY = offset.y
-                                        )
-                                        .fillMaxSize()
+                                        .fillMaxWidth()
+                                        .height(imageHeight)
                                 )
+                            }
+                        }
+                    } else if (displayCodeType == "none" && cardCode.isNotBlank()) {
+                        Card(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 16.dp, bottom = 8.dp)
+                                .height(300.dp)
+                                .shadow(18.dp, RoundedCornerShape(28.dp)),
+                            colors = CardDefaults.cardColors(containerColor = Color.White),
+                            elevation = CardDefaults.cardElevation(defaultElevation = 18.dp),
+                            shape = RoundedCornerShape(28.dp),
+                            border = BorderStroke(1.dp, Color.LightGray.copy(alpha = 0.25f))
+                        ) {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .padding(20.dp)
+                                    .pointerInput(Unit) {
+                                        detectTapGestures(onLongPress = { copyToClipboard() })
+                                    },
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .horizontalScroll(rememberScrollState()),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Text(
+                                        text = cardCode,
+                                        fontSize = plainCodeDisplayFontSize(cardCode),
+                                        fontWeight = FontWeight.Bold,
+                                        color = Color.Black,
+                                        textAlign = TextAlign.Center,
+                                        lineHeight = plainCodeDisplayFontSize(cardCode) * 1.15f,
+                                        modifier = Modifier.padding(vertical = 4.dp)
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    HorizontalDivider(
+                        modifier = Modifier.padding(horizontal = 32.dp),
+                        thickness = 1.dp,
+                        color = colorScheme.onSurface.copy(alpha = 0.2f)
+                    )
+                    // Код карты внизу
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        // Текст кода карты — скрыт для карт без штрих-кода
+                        if (cardCode.isNotBlank() && displayCodeType != "none") {
+                            Card(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 10.dp),
+                                shape = RoundedCornerShape(22.dp),
+                                colors = CardDefaults.cardColors(
+                                    containerColor = colorScheme.surface.copy(
+                                        alpha = 0.20f
+                                    )
+                                ),
+                                elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+                            ) {
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 12.dp, horizontal = 12.dp),
+                                    horizontalAlignment = Alignment.CenterHorizontally
+                                ) {
+                                    val formattedCode =
+                                        formatBarcodeForStandard(cardCode, displayCodeType)
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .horizontalScroll(rememberScrollState())
+                                            .pointerInput(Unit) {
+                                                detectTapGestures(
+                                                    onLongPress = {
+                                                        copyToClipboard()
+                                                    }
+                                                )
+                                            },
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        Text(
+                                            text = formattedCode,
+                                            fontSize = if (cardCode.length > 20) 20.sp else 28.sp,
+                                            fontWeight = FontWeight.Bold,
+                                            color = Color.White,
+                                            textAlign = TextAlign.Center,
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(vertical = 4.dp)
+                                        )
+                                    }
+                                    Spacer(modifier = Modifier.height(6.dp))
+                                    Row(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        horizontalArrangement = Arrangement.Center,
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Default.TouchApp,
+                                            contentDescription = null,
+                                            tint = Color.White.copy(alpha = 0.7f),
+                                            modifier = Modifier.size(16.dp)
+                                        )
+                                        Spacer(modifier = Modifier.width(4.dp))
+                                        Text(
+                                            text = "Долгое нажатие — скопировать",
+                                            fontSize = 11.sp,
+                                            color = Color.White.copy(alpha = 0.7f)
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                        // Заметки и Обложка
+                        Spacer(modifier = Modifier.height(1.dp))
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 10.dp),
+                            horizontalArrangement = Arrangement.spacedBy(
+                                space = 12.dp,
+                                alignment = Alignment.CenterHorizontally
+                            ),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            // Кнопка "Заметки"
+                            Card(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .height(54.dp)
+                                    .pointerInput(Unit) {
+                                        detectTapGestures(
+                                            onTap = { showNoteDialog = true }
+                                        )
+                                    },
+                                shape = RoundedCornerShape(14.dp),
+                                colors = CardDefaults.cardColors(
+                                    containerColor = colorScheme.surface.copy(
+                                        alpha = 0.20f
+                                    )
+                                ),
+                                elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+                            ) {
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .padding(horizontal = 16.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(
+                                        12.dp,
+                                        Alignment.CenterHorizontally
+                                    )
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.Edit,
+                                        contentDescription = "Заметки",
+                                        tint = Color.White,
+                                        modifier = Modifier.size(22.dp)
+                                    )
+                                    Text(
+                                        text = "Заметки",
+                                        color = Color.White,
+                                        fontSize = 15.sp,
+                                        fontWeight = FontWeight.Medium
+                                    )
+                                }
+                            }
+                            // Кнопка "Обложка"
+                            Card(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .height(54.dp),
+                                shape = RoundedCornerShape(14.dp),
+                                colors = CardDefaults.cardColors(
+                                    containerColor = colorScheme.surface.copy(
+                                        alpha = 0.20f
+                                    )
+                                ),
+                                elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+                            ) {
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .clickable(
+                                            interactionSource = remember { MutableInteractionSource() },
+                                            indication = null
+                                        ) { showCoverDialog = true }
+                                        .padding(horizontal = 16.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.spacedBy(
+                                        12.dp,
+                                        Alignment.CenterHorizontally
+                                    )
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Default.Image,
+                                        contentDescription = "Обложка",
+                                        tint = Color.White,
+                                        modifier = Modifier.size(22.dp)
+                                    )
+                                    Text(
+                                        text = "Обложка",
+                                        color = Color.White,
+                                        fontSize = 15.sp,
+                                        fontWeight = FontWeight.Medium
+                                    )
+                                }
+                            }
+                        }
+                        Spacer(modifier = Modifier.height(innerPadding.calculateBottomPadding() + 24.dp))
+                    }
+                }
+                // Диалог для заметки
+                if (showNoteDialog) {
+                    AlertDialog(
+                        onDismissRequest = { showNoteDialog = false },
+                        title = { Text("Заметка к карте") },
+                        text = {
+                            Column {
+                                OutlinedTextField(
+                                    value = noteDraft,
+                                    onValueChange = {
+                                        if (it.length <= 100) {
+                                            noteDraft = it
+                                            noteError = ""
+                                        }
+                                    },
+                                    label = { Text("Введите заметку") },
+                                    singleLine = false,
+                                    maxLines = 4,
+                                    modifier = Modifier.fillMaxWidth(),
+                                    trailingIcon = {
+                                        if (noteDraft.isNotEmpty()) {
+                                            IconButton(onClick = { noteDraft = "" }) {
+                                                Icon(
+                                                    Icons.Default.Close,
+                                                    contentDescription = "Очистить"
+                                                )
+                                            }
+                                        }
+                                    }
+                                )
+                                if (noteError.isNotEmpty()) {
+                                    Text(noteError, color = Color.Red, fontSize = 13.sp)
+                                }
+                            }
+                        },
+                        confirmButton = {
+                            TextButton(
+                                onClick = {
+                                    if (noteDraft.length <= 100) {
+                                        onSaveNote(noteDraft)
+                                        showNoteDialog = false
+                                    } else {
+                                        noteError = "Максимум 100 символов"
+                                    }
+                                }
+                            ) {
+                                Text("Сохранить")
+                            }
+                        },
+                        dismissButton = {
+                            TextButton(onClick = { showNoteDialog = false }) {
+                                Text("Отмена")
+                            }
+                        },
+                        containerColor = colorScheme.surface,
+                        titleContentColor = colorScheme.onSurface,
+                        textContentColor = colorScheme.onSurface
+                    )
+                }
+                // Диалог выбора/просмотра обложки
+                if (showCoverDialog) {
+                    AlertDialog(
+                        onDismissRequest = { showCoverDialog = false },
+                        title = { Text("Обложка карты") },
+                        text = {
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.spacedBy(14.dp)
+                            ) {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .aspectRatio(1.574f)
+                                        .clip(RoundedCornerShape(18.dp))
+                                        .background(colorScheme.surfaceVariant.copy(alpha = 0.7f))
+                                        .clickable {
+                                            when {
+                                                frontCoverPath != null && !frontCoverPath!!.startsWith(
+                                                    "cards/"
+                                                ) ->
+                                                    showFullScreenImage =
+                                                        true to Uri.fromFile(File(frontCoverPath!!))
+
+                                                frontImageUri != null -> showFullScreenImage =
+                                                    true to frontImageUri
+
+                                                coverBitmap != null -> showFullScreenImage =
+                                                    true to null
+                                            }
+                                        },
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    val frontBitmap = frontCoverPath?.let { path ->
+                                        if (path.startsWith("cards/")) null
+                                        else try {
+                                            BitmapFactory.decodeFile(path)
+                                        } catch (_: Exception) {
+                                            null
+                                        }
+                                    } ?: frontImageUri?.let { rememberBitmapFromUri(it) }
+                                    ?: coverBitmap?.let { null }
+                                    if (frontBitmap != null) {
+                                        Image(
+                                            bitmap = frontBitmap.asImageBitmap(),
+                                            contentDescription = "Лицевая обложка",
+                                            contentScale = ContentScale.Crop,
+                                            modifier = Modifier.fillMaxSize()
+                                        )
+                                    } else if (coverBitmap != null) {
+                                        Image(
+                                            bitmap = coverBitmap,
+                                            contentDescription = "Лицевая обложка",
+                                            contentScale = ContentScale.Crop,
+                                            modifier = Modifier.fillMaxSize()
+                                        )
+                                    } else {
+                                        Icon(
+                                            imageVector = Icons.Default.Image,
+                                            contentDescription = null,
+                                            tint = colorScheme.primary,
+                                            modifier = Modifier.size(48.dp)
+                                        )
+                                    }
+                                }
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .aspectRatio(1.574f)
+                                        .clip(RoundedCornerShape(18.dp))
+                                        .background(colorScheme.surfaceVariant.copy(alpha = 0.7f))
+                                        .clickable {
+                                            backCoverPath?.let { path ->
+                                                showFullScreenImage =
+                                                    true to Uri.fromFile(File(path))
+                                            } ?: run {
+                                                if (backImageUri != null) {
+                                                    showFullScreenImage = true to backImageUri
+                                                }
+                                            }
+                                        },
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    val backBitmap = if (backCoverPath != null) {
+                                        try {
+                                            BitmapFactory.decodeFile(backCoverPath)
+                                        } catch (_: Exception) {
+                                            null
+                                        }
+                                    } else rememberBitmapFromUri(backImageUri)
+                                    if (backBitmap != null) {
+                                        Image(
+                                            bitmap = backBitmap.asImageBitmap(),
+                                            contentDescription = "Тыльная обложка",
+                                            contentScale = ContentScale.Crop,
+                                            modifier = Modifier.fillMaxSize()
+                                        )
+                                    } else {
+                                        Icon(
+                                            imageVector = Icons.Default.Image,
+                                            contentDescription = null,
+                                            tint = colorScheme.primary,
+                                            modifier = Modifier.size(48.dp)
+                                        )
+                                    }
+                                }
+                                Text(
+                                    text = "Нажмите на обложку, чтобы увеличить изображение. А изменить обложку, можно в меню изменения карты.",
+                                    fontSize = 13.sp,
+                                    color = colorScheme.onSurfaceVariant,
+                                    textAlign = TextAlign.Center,
+                                    modifier = Modifier.fillMaxWidth()
+                                )
+                            }
+                        },
+                        confirmButton = {
+                            TextButton(onClick = { showCoverDialog = false }) {
+                                Text("Готово")
+                            }
+                        },
+                        containerColor = colorScheme.surface,
+                        titleContentColor = colorScheme.onSurface,
+                        textContentColor = colorScheme.onSurface
+                    )
+                }
+                // Полноэкранный просмотр изображения
+                if (showFullScreenImage.first) {
+                    Dialog(
+                        onDismissRequest = { showFullScreenImage = false to null },
+                        properties = DialogProperties(
+                            usePlatformDefaultWidth = false,
+                            decorFitsSystemWindows = false
+                        )
+                    ) {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .safeDrawingPadding(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            val uri = showFullScreenImage.second
+                            val bitmap =
+                                if (uri != null) rememberBitmapFromUri(uri)?.asImageBitmap() else coverBitmap
+                            if (bitmap != null) {
+                                var scale by remember { mutableStateOf(1f) }
+                                var offset by remember { mutableStateOf(Offset.Zero) }
+                                var lastOffset by remember { mutableStateOf(Offset.Zero) }
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth(0.98f)
+                                        .fillMaxHeight(0.98f)
+                                        .pointerInput(Unit) {
+                                            detectTransformGestures { _, pan, zoom, _ ->
+                                                scale = (scale * zoom).coerceIn(1f, 5f)
+                                                offset += pan
+                                            }
+                                        }
+                                        .pointerInput(Unit) {
+                                            detectTapGestures(onDoubleTap = {
+                                                scale = 1f
+                                                offset = Offset.Zero
+                                            })
+                                        }
+                                ) {
+                                    Image(
+                                        bitmap = bitmap,
+                                        contentDescription = null,
+                                        contentScale = ContentScale.Fit,
+                                        modifier = Modifier
+                                            .graphicsLayer(
+                                                scaleX = scale,
+                                                scaleY = scale,
+                                                translationX = offset.x,
+                                                translationY = offset.y
+                                            )
+                                            .fillMaxSize()
+                                    )
+                                }
                             }
                         }
                     }
                 }
             }
         }
-    }
-    if (showEditFrontCrop && editFrontCropUri != null) {
-        ImageCropDialog(
-            imageUri = editFrontCropUri!!,
-            aspectRatio = 1.574f,
-            onCrop = { croppedBitmap ->
-                val file = File.createTempFile("front_crop_", ".webp", context2.cacheDir)
-                ru.merrcurys.seacard.core.utils.CoverBitmapStorage.saveBitmapAsWebpFile(file, croppedBitmap)
-                editFrontCoverUri = Uri.fromFile(file)
-                editFrontCoverRemoved = false
-                showEditFrontCrop = false
-                editFrontCropUri = null
-            },
-            onDismiss = {
-                showEditFrontCrop = false
-                editFrontCropUri = null
-            }
-        )
-    }
-    if (showEditBackCrop && editBackCropUri != null) {
-        ImageCropDialog(
-            imageUri = editBackCropUri!!,
-            aspectRatio = 1.574f,
-            onCrop = { croppedBitmap ->
-                val file = File.createTempFile("back_crop_", ".webp", context2.cacheDir)
-                ru.merrcurys.seacard.core.utils.CoverBitmapStorage.saveBitmapAsWebpFile(file, croppedBitmap)
-                editBackCoverUri = Uri.fromFile(file)
-                editBackCoverRemoved = false
-                showEditBackCrop = false
-                editBackCropUri = null
-            },
-            onDismiss = {
-                showEditBackCrop = false
-                editBackCropUri = null
-            }
-        )
+        if (showEditFrontCrop && editFrontCropUri != null) {
+            ImageCropDialog(
+                imageUri = editFrontCropUri!!,
+                aspectRatio = 1.574f,
+                onCrop = { croppedBitmap ->
+                    val file = File.createTempFile("front_crop_", ".webp", context2.cacheDir)
+                    ru.merrcurys.seacard.core.utils.CoverBitmapStorage.saveBitmapAsWebpFile(
+                        file,
+                        croppedBitmap
+                    )
+                    editFrontCoverUri = Uri.fromFile(file)
+                    editFrontCoverRemoved = false
+                    showEditFrontCrop = false
+                    editFrontCropUri = null
+                },
+                onDismiss = {
+                    showEditFrontCrop = false
+                    editFrontCropUri = null
+                }
+            )
+        }
+        if (showEditBackCrop && editBackCropUri != null) {
+            ImageCropDialog(
+                imageUri = editBackCropUri!!,
+                aspectRatio = 1.574f,
+                onCrop = { croppedBitmap ->
+                    val file = File.createTempFile("back_crop_", ".webp", context2.cacheDir)
+                    ru.merrcurys.seacard.core.utils.CoverBitmapStorage.saveBitmapAsWebpFile(
+                        file,
+                        croppedBitmap
+                    )
+                    editBackCoverUri = Uri.fromFile(file)
+                    editBackCoverRemoved = false
+                    showEditBackCrop = false
+                    editBackCropUri = null
+                },
+                onDismiss = {
+                    showEditBackCrop = false
+                    editBackCropUri = null
+                }
+            )
+        }
     }
 }

--- a/app/src/main/java/ru/merrcurys/seacard/features/main/CardCoverPickerScreen.kt
+++ b/app/src/main/java/ru/merrcurys/seacard/features/main/CardCoverPickerScreen.kt
@@ -178,15 +178,18 @@ fun CardCoverPickerScreen(
                     colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent)
                 )
             },
-            containerColor = Color.Transparent
+            containerColor = Color.Transparent,
+            contentWindowInsets = WindowInsets.safeDrawing
         ) { innerPadding ->
             Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(innerPadding)
+                    .consumeWindowInsets(innerPadding)
             ) {
                 Column(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(top = innerPadding.calculateTopPadding()),
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
                     OutlinedTextField(
@@ -205,6 +208,7 @@ fun CardCoverPickerScreen(
                             modifier = Modifier
                                 .weight(1f)
                                 .fillMaxWidth()
+                                .padding(bottom = innerPadding.calculateBottomPadding())
                                 .offset(y = (-48).dp),
                             verticalArrangement = Arrangement.Center
                         ) {
@@ -229,7 +233,12 @@ fun CardCoverPickerScreen(
                         LazyVerticalGrid(
                             state = gridState,
                             columns = GridCells.Fixed(2),
-                            contentPadding = PaddingValues(start = 8.dp, top = 8.dp, end = 8.dp, bottom = 92.dp),
+                            contentPadding = PaddingValues(
+                                start = 8.dp,
+                                top = 8.dp,
+                                end = 8.dp,
+                                bottom = innerPadding.calculateBottomPadding() + 84.dp
+                            ),
                             verticalArrangement = Arrangement.spacedBy(8.dp),
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                             flingBehavior = ScrollableDefaults.flingBehavior(),
@@ -313,10 +322,10 @@ fun CardCoverPickerScreen(
                     onClick = { onCoverSelected(null) },
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
-                        .offset(y = (-20).dp)
+                        .padding(horizontal = 12.dp)
+                        .padding(bottom = innerPadding.calculateBottomPadding() + 16.dp)
                         .fillMaxWidth()
                         .height(52.dp)
-                        .padding(horizontal = 12.dp)
                         .border(1.dp, Color.White.copy(alpha = 0.14f), addManualShape),
                     shape = addManualShape,
                     color = Color(0xF21C1C20),

--- a/app/src/main/java/ru/merrcurys/seacard/features/main/MainActivity.kt
+++ b/app/src/main/java/ru/merrcurys/seacard/features/main/MainActivity.kt
@@ -21,12 +21,15 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -74,6 +77,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -164,32 +168,34 @@ class MainActivity : ComponentActivity() {
             }
 
             SeaCardTheme {
-                if (showCoverPicker) {
-                    CardCoverPickerScreen(
-                        onCoverSelected = { coverAsset: String? ->
-                            viewModel.setShowCoverPicker(false)
-                            val intent = Intent(context, ScanCardActivity::class.java)
-                            if (coverAsset != null) intent.putExtra("cover_asset", coverAsset)
-                            scanCardLauncher.launch(intent)
-                        },
-                        onBack = { viewModel.setShowCoverPicker(false) }
-                    )
-                } else {
-                    MainScreen(
-                        cards = cards,
-                        cardsFromDbReady = cardsFromDbReady,
-                        currentSortType = currentSortType,
-                        gridColumns = gridColumns,
-                        gradientColor = gradientColor,
-                        onAddCard = { viewModel.setShowCoverPicker(true) },
-                        onCardClick = { card ->
-                            viewModel.updateCardUsage(card.id)
-                            cardDetailLauncher.launch(Intent(context, CardDetailActivity::class.java).apply { putExtra("card_id", card.id) })
-                        },
-                        onSettingsClick = { settingsLauncher.launch(Intent(context, SettingsActivity::class.java)) },
-                        onSortTypeChange = { viewModel.setSortType(it) },
-                        onDeleteCards = { viewModel.deleteCards(it) }
-                    )
+                GradientBackground(gradientColor = gradientColor) {
+                    if (showCoverPicker) {
+                        CardCoverPickerScreen(
+                            onCoverSelected = { coverAsset: String? ->
+                                viewModel.setShowCoverPicker(false)
+                                val intent = Intent(context, ScanCardActivity::class.java)
+                                if (coverAsset != null) intent.putExtra("cover_asset", coverAsset)
+                                scanCardLauncher.launch(intent)
+                            },
+                            onBack = { viewModel.setShowCoverPicker(false) }
+                        )
+                    } else {
+                        MainScreen(
+                            cards = cards,
+                            cardsFromDbReady = cardsFromDbReady,
+                            currentSortType = currentSortType,
+                            gridColumns = gridColumns,
+                            gradientColor = gradientColor,
+                            onAddCard = { viewModel.setShowCoverPicker(true) },
+                            onCardClick = { card ->
+                                viewModel.updateCardUsage(card.id)
+                                cardDetailLauncher.launch(Intent(context, CardDetailActivity::class.java).apply { putExtra("card_id", card.id) })
+                            },
+                            onSettingsClick = { settingsLauncher.launch(Intent(context, SettingsActivity::class.java)) },
+                            onSortTypeChange = { viewModel.setSortType(it) },
+                            onDeleteCards = { viewModel.deleteCards(it) }
+                        )
+                    }
                 }
             }
         }
@@ -266,6 +272,7 @@ fun MainScreen(
 
         Scaffold(
             containerColor = Color.Transparent,
+            contentWindowInsets = WindowInsets.safeDrawing,
             topBar = {
                 TopAppBar(
                     title = {
@@ -456,7 +463,8 @@ fun MainScreen(
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(innerPadding)
+                        .padding(top = innerPadding.calculateTopPadding())
+                        .consumeWindowInsets(innerPadding)
                         .clickable(
                             interactionSource = remember { MutableInteractionSource() },
                             indication = null
@@ -476,6 +484,7 @@ fun MainScreen(
                             horizontalAlignment = Alignment.CenterHorizontally,
                             modifier = Modifier
                                 .align(Alignment.Center)
+                                .padding(bottom = innerPadding.calculateBottomPadding())
                                 .offset(y = (-64).dp)
                                 .semantics { contentDescription = "Загружаем ваши карты из хранилища" }
                         ) {
@@ -499,7 +508,10 @@ fun MainScreen(
                     } else if (filteredCards.isEmpty()) {
                         Column(
                             horizontalAlignment = Alignment.CenterHorizontally,
-                            modifier = Modifier.align(Alignment.Center).offset(y = (-64).dp)
+                            modifier = Modifier
+                                .align(Alignment.Center)
+                                .padding(bottom = innerPadding.calculateBottomPadding())
+                                .offset(y = (-64).dp)
                         ) {
                             Icon(
                                 imageVector = Icons.Filled.Wallet,
@@ -525,7 +537,12 @@ fun MainScreen(
                     } else {
                         LazyVerticalGrid(
                             columns = GridCells.Fixed(gridColumns.coerceIn(1, 4)),
-                            contentPadding = PaddingValues(start = 8.dp, top = 8.dp, end = 8.dp, bottom = 80.dp),
+                            contentPadding = PaddingValues(
+                                start = 8.dp,
+                                top = 8.dp,
+                                end = 8.dp,
+                                bottom = innerPadding.calculateBottomPadding() + 80.dp
+                            ),
                             verticalArrangement = Arrangement.spacedBy(8.dp),
                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                             flingBehavior = ScrollableDefaults.flingBehavior(),

--- a/app/src/main/java/ru/merrcurys/seacard/features/scan/CardInputSection.kt
+++ b/app/src/main/java/ru/merrcurys/seacard/features/scan/CardInputSection.kt
@@ -554,54 +554,70 @@ fun CardInputSection(
     }
 
     GradientBackground(gradientColor = gradientColor) {
-        Column(
-            modifier = Modifier.fillMaxSize(),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            when {
-                isEditMode -> {
-                    TopAppBar(
-                        title = {
-                            Text(
-                                "Изменить карту",
-                                color = colorScheme.onSurface,
-                                fontWeight = FontWeight.Bold,
-                                textAlign = TextAlign.Start
-                            )
-                        },
-                        navigationIcon = {
-                            IconButton(onClick = onBack) {
-                                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Назад", tint = colorScheme.onSurface)
-                            }
-                        },
-                        colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent)
-                    )
+        Scaffold(
+            containerColor = Color.Transparent,
+            contentWindowInsets = WindowInsets.safeDrawing,
+            topBar = {
+                when {
+                    isEditMode -> {
+                        TopAppBar(
+                            title = {
+                                Text(
+                                    "Изменить карту",
+                                    color = colorScheme.onSurface,
+                                    fontWeight = FontWeight.Bold,
+                                    textAlign = TextAlign.Start
+                                )
+                            },
+                            navigationIcon = {
+                                IconButton(onClick = onBack) {
+                                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Назад", tint = colorScheme.onSurface)
+                                }
+                            },
+                            colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent)
+                        )
+                    }
+                    showTopBar -> {
+                        TopAppBar(
+                            title = {
+                                Text(
+                                    "Добавить карту",
+                                    color = colorScheme.onSurface,
+                                    fontWeight = FontWeight.Bold,
+                                    textAlign = TextAlign.Start
+                                )
+                            },
+                            navigationIcon = {
+                                IconButton(onClick = onBack) {
+                                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Назад", tint = colorScheme.onSurface)
+                                }
+                            },
+                            colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent)
+                        )
+                    }
+                    else -> Unit
                 }
-                showTopBar -> {
-                    TopAppBar(
-                        title = {
-                            Text(
-                                "Добавить карту",
-                                color = colorScheme.onSurface,
-                                fontWeight = FontWeight.Bold,
-                                textAlign = TextAlign.Start
-                            )
-                        },
-                        navigationIcon = {
-                            IconButton(onClick = onBack) {
-                                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Назад", tint = colorScheme.onSurface)
-                            }
-                        },
-                        colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent)
-                    )
-                }
-                else -> {
-                    Spacer(modifier = Modifier.height(32.dp))
+            },
+            bottomBar = {
+                Button(
+                    onClick = onSaveCard,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 12.dp)
+                        .navigationBarsPadding()
+                        .imePadding(),
+                    colors = ButtonDefaults.buttonColors(containerColor = colorScheme.primary),
+                    enabled = canSave
+                ) {
+                    Text("Сохранить карту", color = colorScheme.onPrimary)
                 }
             }
-
+        ) { innerPadding ->
             Box(
-                modifier = Modifier.weight(1f)
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .consumeWindowInsets(innerPadding)
             ) {
                 Column(
                     modifier = Modifier
@@ -745,18 +761,6 @@ fun CardInputSection(
                     }
                     Spacer(modifier = Modifier.height(16.dp))
                 }
-            }
-
-            Button(
-                onClick = onSaveCard,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 16.dp)
-                    .navigationBarsPadding(),
-                colors = ButtonDefaults.buttonColors(containerColor = colorScheme.primary),
-                enabled = canSave
-            ) {
-                Text("Сохранить карту", color = colorScheme.onPrimary)
             }
         }
     }

--- a/app/src/main/java/ru/merrcurys/seacard/features/scan/ManualBarcodeSelectionScreen.kt
+++ b/app/src/main/java/ru/merrcurys/seacard/features/scan/ManualBarcodeSelectionScreen.kt
@@ -78,30 +78,41 @@ fun ManualBarcodeSelectionScreen(
     }
 
     GradientBackground(gradientColor = gradientColor) {
-        Column(modifier = Modifier.fillMaxSize()) {
-            TopAppBar(
-                title = {
-                    Text(
-                        "Выбор штрих-кода",
-                        color = colorScheme.onSurface,
-                        fontWeight = FontWeight.Bold
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Назад",
-                            tint = colorScheme.onSurface
+        Scaffold(
+            containerColor = Color.Transparent,
+            contentWindowInsets = WindowInsets.safeDrawing,
+            topBar = {
+                TopAppBar(
+                    title = {
+                        Text(
+                            "Выбор штрих-кода",
+                            color = colorScheme.onSurface,
+                            fontWeight = FontWeight.Bold
                         )
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent)
-            )
-
+                    },
+                    navigationIcon = {
+                        IconButton(onClick = onBack) {
+                            Icon(
+                                Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = "Назад",
+                                tint = colorScheme.onSurface
+                            )
+                        }
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent)
+                )
+            }
+        ) { innerPadding ->
             LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(start = 16.dp, end = 16.dp, bottom = 24.dp),
+                modifier = Modifier
+                    .fillMaxSize()
+                    .consumeWindowInsets(innerPadding),
+                contentPadding = PaddingValues(
+                    start = 16.dp,
+                    top = innerPadding.calculateTopPadding() + 8.dp,
+                    end = 16.dp,
+                    bottom = innerPadding.calculateBottomPadding() + 24.dp
+                ),
                 verticalArrangement = Arrangement.spacedBy(14.dp)
             ) {
                 item {

--- a/app/src/main/java/ru/merrcurys/seacard/features/scan/ScanCardActivity.kt
+++ b/app/src/main/java/ru/merrcurys/seacard/features/scan/ScanCardActivity.kt
@@ -793,13 +793,15 @@ fun CameraSection(
                 textAlign = TextAlign.Center,
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
-                    .padding(bottom = 120.dp, start = 32.dp, end = 32.dp)
+                    .navigationBarsPadding()
+                    .padding(bottom = 76.dp, start = 32.dp, end = 32.dp)
             )
             // Кнопка альтернативного способа (варианты / галерея)
             Box(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
-                    .padding(bottom = 56.dp)
+                    .navigationBarsPadding()
+                    .padding(bottom = 20.dp)
             ) {
                 Button(
                     onClick = onOptionsClick,

--- a/app/src/main/java/ru/merrcurys/seacard/features/settings/SettingsActivity.kt
+++ b/app/src/main/java/ru/merrcurys/seacard/features/settings/SettingsActivity.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import ru.merrcurys.seacard.core.design.applySeaCardSystemBarColors
@@ -73,6 +74,7 @@ import android.net.Uri
 import androidx.activity.result.contract.ActivityResultContracts
 import java.nio.charset.StandardCharsets
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.ui.graphics.Brush
 import ru.merrcurys.seacard.BuildConfig
 import ru.merrcurys.seacard.core.design.BerlinAzure
 import ru.merrcurys.seacard.core.design.GradientColorOption
@@ -232,6 +234,7 @@ fun SettingsScreen(
 
     Scaffold(
         containerColor = Color.Transparent,
+        contentWindowInsets = WindowInsets.safeDrawing,
         topBar = {
             TopAppBar(
                 title = { Text("Настройки", fontWeight = FontWeight.SemiBold) },
@@ -240,11 +243,7 @@ fun SettingsScreen(
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Назад")
                     }
                 },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = topBarContainerColor,
-                    titleContentColor = colorScheme.onSurface,
-                    navigationIconContentColor = colorScheme.onSurface
-                )
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = Color.Transparent)
             )
         }
     ) { innerPadding ->
@@ -252,9 +251,14 @@ fun SettingsScreen(
             state = listState,
             modifier = Modifier
                 .fillMaxSize()
-                .padding(innerPadding)
-                .navigationBarsPadding(),
-            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
+                .padding(top = innerPadding.calculateTopPadding())
+                .consumeWindowInsets(innerPadding),
+            contentPadding = PaddingValues(
+                start = 16.dp,
+                top = 12.dp,
+                end = 16.dp,
+                bottom = innerPadding.calculateBottomPadding() + 16.dp
+            ),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             item {


### PR DESCRIPTION
### Summary:
  This PR applies edge-to-edge support and unifies the top app bar gradient background styling across CardCoverPickerScreen.kt, MainActivity.kt, and SettingsActivity.kt
  ### Changes:
  - **CardCoverPickerScreen.kt**:
      - Fixed solid navigation bar background by removing full innerPadding from the root Box and consuming window insets properly
      - Placed top bar insets on the content column (padding(top = innerPadding.calculateTopPadding()))
      - Added bottom navigation bar insets to the LazyVerticalGrid's contentPadding and the "Добавить вручную" Surface button
      - Screen content now seamlessly scrolls edge-to-edge behind the transparent navigation bar
  - **MainActivity.kt**:
      - Wrapped root setContent in Theme.kt:44 for consistent theme gradients during state transitions and picker views
      - Adjusted content Box layout with .padding(top = innerPadding.calculateTopPadding()) so card items clip cleanly below the top app bar rather than overlapping title actions
      - Maintained edge-to-edge scrolling behind the transparent navigation bar with bottom insets
  - **SettingsActivity.kt**:
    - SettingsScreen LazyColumn container to pad innerPadding.calculateTopPadding(), ensuring settings items clip below the top app bar while scrolling behind the transparent navigation bar at the bottom